### PR TITLE
Remove requirement for majority of environment variables, fix some compile-time issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "concrete"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "env_logger",
+ "idna",
+ "log",
+ "parking_lot",
+ "quinn",
+ "rand",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,27 +585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quiclime"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "env_logger",
- "idna",
- "log",
- "parking_lot",
- "quinn",
- "rand",
- "rustls",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -1,0 +1,8 @@
+pub const QUICLIME_BASE_DOMAIN: &str = "mc.lunapixel.gg";
+pub const QUICLIME_BIND_ADDR_MC: &str = "0.0.0.0:25565";
+pub const QUICLIME_BIND_ADDR_QUIC: &str = "0.0.0.0:25575";
+pub const QUICLIME_BIND_ADDR_WEB: &str = "127.0.0.1:25585";
+/*
+pub const QUICLIME_CERT_PATH: &str = "fullchain.pem";
+pub const QUICLIME_KEY_PATH: &str = "key.pem";
+*/


### PR DESCRIPTION
Cargo.toml newest "edition" specifier is 2021, its not the edition of the project but rather Cargo itself.

I was having trouble compiling wordlist.rs with size being 2048, bumped it down to the actual size of the array and it worked. i thought 2048 would be an upper limit, or constant check, but i mustve mixed up vectors and arrays, my bad :p

We still need `QUICLIME_CERT_PATH` and `QUICLIME_KEY_PATH` due to the fact that their paths are variable to our system.